### PR TITLE
feat(transform): add primitive node transformation support

### DIFF
--- a/packages/react-jsonr/src/index.ts
+++ b/packages/react-jsonr/src/index.ts
@@ -1,5 +1,22 @@
 // Main entry point for React-JSONR
 export { renderNode } from './rendering';
 export { transformJsonTree, traverseJsonTree } from './transformation';
-export type { JsonNode, ComponentRegistry, TransformVisitor, TransformContext, RenderContext } from './types';
+export type { 
+  JsonNode, 
+  ComponentNode, 
+  ComponentRegistry, 
+  TransformVisitor, 
+  TransformContext, 
+  RenderContext 
+} from './types';
+export { 
+  isComponentNode,
+  isPrimitiveNode,
+  isArrayNode,
+  createComponentNode,
+  createFragment,
+  createPortal,
+  FRAGMENT,
+  PORTAL
+} from './types';
 export type { TraverseOptions } from './transformation'; 

--- a/packages/react-jsonr/src/rendering.ts
+++ b/packages/react-jsonr/src/rendering.ts
@@ -1,11 +1,54 @@
 import React, { ReactNode, createElement } from 'react';
-import { JsonNode, ComponentRegistry, RenderContext } from './types';
+import { createPortal } from 'react-dom';
+import { 
+  JsonNode, 
+  ComponentNode, 
+  ComponentRegistry, 
+  RenderContext,
+  isPrimitiveNode,
+  isArrayNode,
+  FRAGMENT,
+  PORTAL
+} from './types';
 
 /**
  * Renders a JSON node to a React element
  */
 export function renderNode(
   node: JsonNode,
+  registry: ComponentRegistry,
+  context: RenderContext = {}
+): ReactNode {
+  // Handle primitives directly
+  if (isPrimitiveNode(node)) {
+    return node;
+  }
+  
+  // Handle arrays
+  if (isArrayNode(node)) {
+    return node.map((child, index) => {
+      // Add stable keys to array children to avoid React warnings
+      const element = renderNode(child, registry, context);
+      
+      // For primitive values or when the element is an array itself, wrap with a key
+      if (isPrimitiveNode(child) || Array.isArray(element)) {
+        return React.createElement(React.Fragment, { key: `item-${index}` }, element);
+      }
+      
+      // For component nodes, the key is already handled in renderComponentNode
+      return element;
+    });
+  }
+  
+  // From here, we know it's a ComponentNode
+  return renderComponentNode(node, registry, context);
+}
+
+/**
+ * Renders a component node to a React element
+ */
+function renderComponentNode(
+  node: ComponentNode,
   registry: ComponentRegistry,
   context: RenderContext = {}
 ): ReactNode {
@@ -25,11 +68,23 @@ export function renderNode(
     processedProps.key = key;
   }
   
-  // Recursively render children if they exist
-  let children: ReactNode[] = [];
-  if (node.children && node.children.length > 0) {
-    children = node.children.map((child, index) => 
-      renderNode(child, registry, context)
+  // Handle special component types
+  if (node.type === FRAGMENT) {
+    return React.createElement(
+      React.Fragment,
+      processedProps,
+      renderNodeChildren(node.children, registry, context)
+    );
+  }
+  
+  if (node.type === PORTAL) {
+    const target = typeof processedProps.container === 'string'
+      ? document.querySelector(processedProps.container)
+      : processedProps.container || document.body;
+      
+    return createPortal(
+      renderNodeChildren(node.children, registry, context),
+      target
     );
   }
   
@@ -37,8 +92,38 @@ export function renderNode(
   return createElement(
     component,
     processedProps,
-    ...(children.length > 0 ? children : [])
+    renderNodeChildren(node.children, registry, context)
   );
+}
+
+/**
+ * Renders children nodes
+ */
+function renderNodeChildren(
+  children: JsonNode | JsonNode[] | undefined,
+  registry: ComponentRegistry,
+  context: RenderContext
+): ReactNode {
+  if (!children) {
+    return null;
+  }
+  
+  if (isArrayNode(children)) {
+    return children.map((child, index) => {
+      // Add stable keys to array children to avoid React warnings
+      const element = renderNode(child, registry, context);
+      
+      // For primitive values or when the element is an array itself, wrap with a key
+      if (isPrimitiveNode(child) || Array.isArray(element)) {
+        return React.createElement(React.Fragment, { key: `item-${index}` }, element);
+      }
+      
+      // For component nodes, the key is already handled in renderComponentNode
+      return element;
+    });
+  }
+  
+  return renderNode(children, registry, context);
 }
 
 /**

--- a/packages/react-jsonr/src/rendering.ts
+++ b/packages/react-jsonr/src/rendering.ts
@@ -30,11 +30,6 @@ export function renderNode(
       // Add stable keys to array children to avoid React warnings
       const element = renderNode(child, registry, context);
       
-      // For primitive values or when the element is an array itself, wrap with a key
-      if (isPrimitiveNode(child) || Array.isArray(element)) {
-        return React.createElement(React.Fragment, { key: `item-${index}` }, element);
-      }
-      
       // For component nodes, the key is already handled in renderComponentNode
       return element;
     });
@@ -112,11 +107,6 @@ function renderNodeChildren(
     return children.map((child, index) => {
       // Add stable keys to array children to avoid React warnings
       const element = renderNode(child, registry, context);
-      
-      // For primitive values or when the element is an array itself, wrap with a key
-      if (isPrimitiveNode(child) || Array.isArray(element)) {
-        return React.createElement(React.Fragment, { key: `item-${index}` }, element);
-      }
       
       // For component nodes, the key is already handled in renderComponentNode
       return element;

--- a/packages/react-jsonr/src/transformation.ts
+++ b/packages/react-jsonr/src/transformation.ts
@@ -1,11 +1,11 @@
-import { JsonNode, TransformVisitor, TransformContext, TransformOptions } from './types';
+import { JsonNode, ComponentNode, TransformVisitor, TransformContext, TransformOptions, isComponentNode, isPrimitiveNode, isArrayNode } from './types';
 
 /**
  * Default transform options
  */
 const defaultOptions: TransformOptions = {
   order: 'depthFirstPre',
-  clone: true,
+  clone: true
 };
 
 /**
@@ -13,40 +13,92 @@ const defaultOptions: TransformOptions = {
  */
 function createContext(
   node: JsonNode,
-  parent: JsonNode | null,
+  parent: ComponentNode | null,
   index: number,
   depth: number
 ): TransformContext {
-  let skipChildrenFlag = false;
-  
-  return {
+  const context: TransformContext = {
     depth,
     parent,
     index,
+    shouldSkipChildren: false,
     skipChildren() {
-      skipChildrenFlag = true;
-    },
-    get shouldSkipChildren() {
-      return skipChildrenFlag;
-    },
+      context.shouldSkipChildren = true;
+    }
   };
+  return context;
 }
 
 /**
- * Transforms a JSON tree using provided visitors
+ * Transforms a JSON tree by applying visitors to each node
  */
 export async function transformJsonTree(
   root: JsonNode,
   visitors: TransformVisitor[],
   options: TransformOptions = defaultOptions
 ): Promise<JsonNode> {
+  // Skip transformation if there are no visitors
+  if (visitors.length === 0) {
+    return root;
+  }
+  
+  // If it's a primitive, apply transformations
+  if (isPrimitiveNode(root)) {
+    let node: JsonNode = root;
+    const context = createContext(node, null, 0, 0);
+    
+    // Apply enter visitors
+    for (const visitor of visitors) {
+      if (visitor.enter) {
+        const result = await visitor.enter(node, context);
+        if (result !== undefined) {
+          node = result;
+          // If node was transformed to a non-primitive, stop primitive processing
+          if (!isPrimitiveNode(node)) {
+            return node;
+          }
+        }
+      }
+    }
+    
+    // Apply exit visitors
+    for (const visitor of visitors) {
+      if (visitor.exit) {
+        const result = await visitor.exit(node, context);
+        if (result !== undefined) {
+          node = result;
+          // If node was transformed to a non-primitive, stop primitive processing
+          if (!isPrimitiveNode(node)) {
+            break;
+          }
+        }
+      }
+    }
+    
+    return node;
+  }
+  
+  // If it's an array, transform each element
+  if (isArrayNode(root)) {
+    const shouldClone = options.clone ?? defaultOptions.clone;
+    const clonedArray = shouldClone ? [...root] : root;
+    
+    // Transform each element in the array
+    for (let i = 0; i < clonedArray.length; i++) {
+      clonedArray[i] = await transformJsonTree(clonedArray[i], visitors, options);
+    }
+    
+    return clonedArray;
+  }
+  
+  // At this point we know it's a ComponentNode
   // Clone the input only if requested (default) to avoid mutating the original
   const rootNode = options.clone ?? defaultOptions.clone 
     ? JSON.parse(JSON.stringify(root))
     : root;
   
-  // Use depth-first pre-order traversal by default
-  const order = options.order || defaultOptions.order;
+  // Choose traversal strategy based on the order option
+  const order = options.order ?? defaultOptions.order;
   
   switch (order) {
     case 'depthFirstPre':
@@ -59,7 +111,7 @@ export async function transformJsonTree(
       await breadthFirst(rootNode, visitors);
       break;
     default:
-      await depthFirstPreOrder(rootNode, visitors);
+      throw new Error(`Invalid traversal order: ${order}`);
   }
   
   return rootNode;
@@ -71,32 +123,73 @@ export async function transformJsonTree(
 async function depthFirstPreOrder(
   node: JsonNode, 
   visitors: TransformVisitor[],
-  parent: JsonNode | null = null,
+  parent: ComponentNode | null = null,
   index = 0,
   depth = 0
 ): Promise<void> {
+  // For primitives, just apply visitors and return
+  if (isPrimitiveNode(node)) {
+    // Primitive nodes are handled separately in transformJsonTree
+    return;
+  }
+  
+  // For arrays, process each item
+  if (isArrayNode(node)) {
+    for (let i = 0; i < node.length; i++) {
+      await depthFirstPreOrder(node[i], visitors, parent, i, depth);
+    }
+    return;
+  }
+  
+  // From here we know it's a component node
   // Create context for this node
   const context = createContext(node, parent, index, depth);
   
   // Run enter visitors
   for (const visitor of visitors) {
     if (visitor.enter) {
-      await visitor.enter(node, context);
+      const result = await visitor.enter(node, context);
+      if (result !== undefined) {
+        // If the node was transformed, we stop traversal for this node
+        // as the structure might have changed
+        return;
+      }
     }
   }
   
   // Process children if they exist and are not skipped
-  if (node.children && !context.shouldSkipChildren) {
-    for (let i = 0; i < node.children.length; i++) {
-      await depthFirstPreOrder(node.children[i], visitors, node, i, depth + 1);
-    }
+  if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+    await processChildren(node.children, visitors, node, depth);
   }
   
   // Run exit visitors
   for (const visitor of visitors) {
     if (visitor.exit) {
-      await visitor.exit(node, context);
+      const result = await visitor.exit(node, context);
+      if (result !== undefined) {
+        // Same as for enter, if node was transformed we stop here
+        return;
+      }
     }
+  }
+}
+
+/**
+ * Process children of a node which can be a single node or an array
+ */
+async function processChildren(
+  children: JsonNode | JsonNode[],
+  visitors: TransformVisitor[],
+  parent: ComponentNode,
+  depth: number
+): Promise<void> {
+  if (isArrayNode(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      await depthFirstPreOrder(child, visitors, parent, i, depth + 1);
+    }
+  } else {
+    await depthFirstPreOrder(children, visitors, parent, 0, depth + 1);
   }
 }
 
@@ -106,32 +199,72 @@ async function depthFirstPreOrder(
 async function depthFirstPostOrder(
   node: JsonNode, 
   visitors: TransformVisitor[],
-  parent: JsonNode | null = null,
+  parent: ComponentNode | null = null,
   index = 0,
   depth = 0
 ): Promise<void> {
+  // For primitives, just apply visitors and return
+  if (isPrimitiveNode(node)) {
+    // Primitive nodes are handled separately in transformJsonTree
+    return;
+  }
+  
+  // For arrays, process each item
+  if (isArrayNode(node)) {
+    for (let i = 0; i < node.length; i++) {
+      await depthFirstPostOrder(node[i], visitors, parent, i, depth);
+    }
+    return;
+  }
+  
+  // From here we know it's a component node
   // Create context for this node
   const context = createContext(node, parent, index, depth);
   
   // Process children first if they exist and are not skipped
-  if (node.children && !context.shouldSkipChildren) {
-    for (let i = 0; i < node.children.length; i++) {
-      await depthFirstPostOrder(node.children[i], visitors, node, i, depth + 1);
-    }
+  if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+    await processChildrenPostOrder(node.children, visitors, node, depth);
   }
   
   // Run enter visitors
   for (const visitor of visitors) {
     if (visitor.enter) {
-      await visitor.enter(node, context);
+      const result = await visitor.enter(node, context);
+      if (result !== undefined) {
+        // If the node was transformed, we stop traversal for this node
+        return;
+      }
     }
   }
   
   // Run exit visitors
   for (const visitor of visitors) {
     if (visitor.exit) {
-      await visitor.exit(node, context);
+      const result = await visitor.exit(node, context);
+      if (result !== undefined) {
+        // If the node was transformed, we stop traversal for this node
+        return;
+      }
     }
+  }
+}
+
+/**
+ * Process children of a node for post-order traversal
+ */
+async function processChildrenPostOrder(
+  children: JsonNode | JsonNode[],
+  visitors: TransformVisitor[],
+  parent: ComponentNode,
+  depth: number
+): Promise<void> {
+  if (isArrayNode(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      await depthFirstPostOrder(child, visitors, parent, i, depth + 1);
+    }
+  } else {
+    await depthFirstPostOrder(children, visitors, parent, 0, depth + 1);
   }
 }
 
@@ -142,74 +275,170 @@ async function breadthFirst(
   root: JsonNode, 
   visitors: TransformVisitor[]
 ): Promise<void> {
+  // For primitives, just apply visitors and return
+  if (isPrimitiveNode(root)) {
+    // Primitive nodes are handled separately in transformJsonTree
+    return;
+  }
+  
+  // For arrays, process each item separately in a breadth-first manner
+  if (isArrayNode(root)) {
+    for (let i = 0; i < root.length; i++) {
+      await breadthFirst(root[i], visitors);
+    }
+    return;
+  }
+  
+  // From here we know it's a component node
   const queue: Array<{
     node: JsonNode;
-    parent: JsonNode | null;
+    parent: ComponentNode | null;
     index: number;
     depth: number;
   }> = [{ node: root, parent: null, index: 0, depth: 0 }];
   
   while (queue.length > 0) {
     const { node, parent, index, depth } = queue.shift()!;
+    
+    // Skip primitives - they are handled separately in transformJsonTree
+    if (isPrimitiveNode(node)) {
+      continue;
+    }
+    
+    // Skip arrays - we process them differently
+    if (isArrayNode(node)) {
+      for (let i = 0; i < node.length; i++) {
+        queue.push({
+          node: node[i],
+          parent,
+          index: i,
+          depth
+        });
+      }
+      continue;
+    }
+    
+    // Create context for this node
     const context = createContext(node, parent, index, depth);
     
-    // Run visitors (enter only, as exit doesn't make sense in BFS)
+    // Run enter visitors
+    let shouldContinue = true;
     for (const visitor of visitors) {
       if (visitor.enter) {
-        await visitor.enter(node, context);
+        const result = await visitor.enter(node, context);
+        if (result !== undefined) {
+          // If the node was transformed, we stop processing this node
+          shouldContinue = false;
+          break;
+        }
       }
     }
     
-    // Add children to queue if they exist and are not skipped
-    if (node.children && !context.shouldSkipChildren) {
-      for (let i = 0; i < node.children.length; i++) {
-        queue.push({
-          node: node.children[i],
-          parent: node,
-          index: i,
-          depth: depth + 1
-        });
+    if (!shouldContinue) {
+      continue;
+    }
+    
+    // Run exit visitors
+    for (const visitor of visitors) {
+      if (visitor.exit) {
+        const result = await visitor.exit(node, context);
+        if (result !== undefined) {
+          // If the node was transformed, we stop processing
+          shouldContinue = false;
+          break;
+        }
       }
+    }
+    
+    if (!shouldContinue) {
+      continue;
+    }
+    
+    // Add children to queue if they exist and are not skipped
+    if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+      await enqueueChildren(queue, node.children, node, depth);
     }
   }
 }
 
 /**
- * Options for JSON tree traversal using generator
+ * Enqueues children for breadth-first traversal
  */
-export interface TraverseOptions extends TransformOptions {
-  nodeTypes?: string[];  // Types of nodes to yield (empty = all)
+async function enqueueChildren(
+  queue: Array<{node: JsonNode, parent: ComponentNode | null, index: number, depth: number}>,
+  children: JsonNode | JsonNode[],
+  parent: ComponentNode,
+  depth: number
+): Promise<void> {
+  if (isArrayNode(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      queue.push({
+        node: child,
+        parent,
+        index: i,
+        depth: depth + 1
+      });
+    }
+  } else {
+    queue.push({
+      node: children,
+      parent,
+      index: 0,
+      depth: depth + 1
+    });
+  }
 }
 
 /**
- * Generator function that traverses a JSON tree and yields each node
- * Allows the caller to modify nodes during traversal
+ * Options for traversal
+ */
+export interface TraverseOptions extends TransformOptions {
+  nodeTypes?: string[]; // Filter nodes by type (only applies to ComponentNodes)
+}
+
+/**
+ * Traverses a JSON tree and yields each node with its context
  */
 export function* traverseJsonTree(
   root: JsonNode,
   options: TraverseOptions = {}
 ): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  // If it's a primitive, yield it
+  if (isPrimitiveNode(root)) {
+    const context = createContext(root, null, 0, 0);
+    yield { node: root, context };
+    return;
+  }
+  
+  if (isArrayNode(root)) {
+    for (let i = 0; i < root.length; i++) {
+      yield* traverseJsonTree(root[i], options);
+    }
+    return;
+  }
+  
   // Clone the input if requested (default: false for traverseJsonTree)
-  const shouldClone = options.clone !== undefined ? options.clone : false;
+  const shouldClone = options.clone ?? false;
   const rootNode = shouldClone 
     ? JSON.parse(JSON.stringify(root))
     : root;
-    
-  // Use depth-first pre-order traversal by default
-  const order = options.order || defaultOptions.order;
+  
+  const order = options.order || 'depthFirstPre';
+  const nodeTypes = options.nodeTypes;
   
   switch (order) {
     case 'depthFirstPre':
-      yield* traverseDepthFirstPre(rootNode, options.nodeTypes);
+      yield* traverseDepthFirstPre(rootNode, nodeTypes);
       break;
     case 'depthFirstPost':
-      yield* traverseDepthFirstPost(rootNode, options.nodeTypes);
+      yield* traverseDepthFirstPost(rootNode, nodeTypes);
       break;
     case 'breadthFirst':
-      yield* traverseBreadthFirst(rootNode, options.nodeTypes);
+      yield* traverseBreadthFirst(rootNode, nodeTypes);
       break;
     default:
-      yield* traverseDepthFirstPre(rootNode, options.nodeTypes);
+      throw new Error(`Invalid traversal order: ${order}`);
   }
 }
 
@@ -219,23 +448,56 @@ export function* traverseJsonTree(
 function* traverseDepthFirstPre(
   node: JsonNode, 
   nodeTypes?: string[],
-  parent: JsonNode | null = null,
+  parent: ComponentNode | null = null,
   index = 0,
   depth = 0
 ): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  // For primitives, just yield with context
+  if (isPrimitiveNode(node)) {
+    const context = createContext(node, parent, index, depth);
+    yield { node, context };
+    return;
+  }
+  
+  // Handle arrays
+  if (isArrayNode(node)) {
+    for (let i = 0; i < node.length; i++) {
+      yield* traverseDepthFirstPre(node[i], nodeTypes, parent, i, depth);
+    }
+    return;
+  }
+  
   // Create context for this node
   const context = createContext(node, parent, index, depth);
   
   // Yield the node if it matches the filter or if no filter is provided
-  if (!nodeTypes || nodeTypes.length === 0 || nodeTypes.includes(node.type)) {
+  if (!nodeTypes || 
+      (isComponentNode(node) && nodeTypes.includes(node.type))) {
     yield { node, context };
   }
   
   // Process children if they exist and are not skipped
-  if (node.children && !context.shouldSkipChildren) {
-    for (let i = 0; i < node.children.length; i++) {
-      yield* traverseDepthFirstPre(node.children[i], nodeTypes, node, i, depth + 1);
+  if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+    yield* traverseChildrenPreOrder(node.children, node, depth, nodeTypes);
+  }
+}
+
+/**
+ * Traverse children for pre-order depth-first
+ */
+function* traverseChildrenPreOrder(
+  children: JsonNode | JsonNode[],
+  parent: ComponentNode,
+  depth: number,
+  nodeTypes?: string[]
+): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  if (isArrayNode(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      yield* traverseDepthFirstPre(child, nodeTypes, parent, i, depth + 1);
     }
+  } else {
+    yield* traverseDepthFirstPre(children, nodeTypes, parent, 0, depth + 1);
   }
 }
 
@@ -245,23 +507,56 @@ function* traverseDepthFirstPre(
 function* traverseDepthFirstPost(
   node: JsonNode, 
   nodeTypes?: string[],
-  parent: JsonNode | null = null,
+  parent: ComponentNode | null = null,
   index = 0,
   depth = 0
 ): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  // For primitives, just yield with context
+  if (isPrimitiveNode(node)) {
+    const context = createContext(node, parent, index, depth);
+    yield { node, context };
+    return;
+  }
+  
+  // Handle arrays
+  if (isArrayNode(node)) {
+    for (let i = 0; i < node.length; i++) {
+      yield* traverseDepthFirstPost(node[i], nodeTypes, parent, i, depth);
+    }
+    return;
+  }
+  
   // Create context for this node
   const context = createContext(node, parent, index, depth);
   
   // Process children first if they exist and are not skipped
-  if (node.children && !context.shouldSkipChildren) {
-    for (let i = 0; i < node.children.length; i++) {
-      yield* traverseDepthFirstPost(node.children[i], nodeTypes, node, i, depth + 1);
-    }
+  if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+    yield* traverseChildrenPostOrder(node.children, node, depth, nodeTypes);
   }
   
   // Yield the node if it matches the filter or if no filter is provided
-  if (!nodeTypes || nodeTypes.length === 0 || nodeTypes.includes(node.type)) {
+  if (!nodeTypes || 
+      (isComponentNode(node) && nodeTypes.includes(node.type))) {
     yield { node, context };
+  }
+}
+
+/**
+ * Traverse children for post-order depth-first
+ */
+function* traverseChildrenPostOrder(
+  children: JsonNode | JsonNode[],
+  parent: ComponentNode,
+  depth: number,
+  nodeTypes?: string[]
+): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  if (isArrayNode(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      yield* traverseDepthFirstPost(child, nodeTypes, parent, i, depth + 1);
+    }
+  } else {
+    yield* traverseDepthFirstPost(children, nodeTypes, parent, 0, depth + 1);
   }
 }
 
@@ -272,29 +567,77 @@ function* traverseBreadthFirst(
   root: JsonNode, 
   nodeTypes?: string[]
 ): Generator<{node: JsonNode, context: TransformContext}, void, void> {
+  // For primitives, just yield with context
+  if (isPrimitiveNode(root)) {
+    const context = createContext(root, null, 0, 0);
+    yield { node: root, context };
+    return;
+  }
+  
+  // Handle arrays
+  if (isArrayNode(root)) {
+    for (let i = 0; i < root.length; i++) {
+      yield* traverseBreadthFirst(root[i], nodeTypes);
+    }
+    return;
+  }
+  
   const queue: Array<{
     node: JsonNode;
-    parent: JsonNode | null;
+    parent: ComponentNode | null;
     index: number;
     depth: number;
   }> = [{ node: root, parent: null, index: 0, depth: 0 }];
   
   while (queue.length > 0) {
     const { node, parent, index, depth } = queue.shift()!;
+    
+    // For primitives, just yield with context
+    if (isPrimitiveNode(node)) {
+      const context = createContext(node, parent, index, depth);
+      yield { node, context };
+      continue;
+    }
+    
+    // Handle arrays - add each item to queue
+    if (isArrayNode(node)) {
+      for (let i = 0; i < node.length; i++) {
+        queue.push({
+          node: node[i],
+          parent,
+          index: i,
+          depth
+        });
+      }
+      continue;
+    }
+    
+    // Create context for this component node
     const context = createContext(node, parent, index, depth);
     
     // Yield the node if it matches the filter or if no filter is provided
-    if (!nodeTypes || nodeTypes.length === 0 || nodeTypes.includes(node.type)) {
+    if (!nodeTypes || 
+        (isComponentNode(node) && nodeTypes.includes(node.type))) {
       yield { node, context };
     }
     
-    // Add children to queue if they exist and are not skipped
-    if (node.children && !context.shouldSkipChildren) {
-      for (let i = 0; i < node.children.length; i++) {
+    // Add children to queue
+    if (isComponentNode(node) && node.children && !context.shouldSkipChildren) {
+      if (isArrayNode(node.children)) {
+        for (let i = 0; i < node.children.length; i++) {
+          const child = node.children[i];
+          queue.push({
+            node: child,
+            parent: node,
+            index: i,
+            depth: depth + 1
+          });
+        }
+      } else {
         queue.push({
-          node: node.children[i],
+          node: node.children,
           parent: node,
-          index: i,
+          index: 0,
           depth: depth + 1
         });
       }

--- a/packages/react-jsonr/src/types.ts
+++ b/packages/react-jsonr/src/types.ts
@@ -1,12 +1,24 @@
 import { ReactNode, ComponentType } from 'react';
 
 /**
- * Represents a JSON node that can be rendered to a React component
+ * Base type for all possible nodes in the JSON representation
  */
-export interface JsonNode {
+export type JsonNode = 
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | ComponentNode
+  | JsonNode[]; // For arrays of nodes
+
+/**
+ * Component node with type and props
+ */
+export interface ComponentNode {
   type: string;
   props?: Record<string, any>;
-  children?: JsonNode[];
+  children?: JsonNode | JsonNode[];
   key?: string;
   id?: string;
 }
@@ -23,7 +35,7 @@ export type ComponentRegistry = {
  */
 export interface TransformContext {
   depth: number;
-  parent: JsonNode | null;
+  parent: ComponentNode | null;
   index: number;
   skipChildren(): void;
   [key: string]: any;
@@ -33,8 +45,8 @@ export interface TransformContext {
  * Visitor interface for transform plugins
  */
 export interface TransformVisitor {
-  enter?(node: JsonNode, context: TransformContext): void | Promise<void>;
-  exit?(node: JsonNode, context: TransformContext): void | Promise<void>;
+  enter?(node: JsonNode, context: TransformContext): JsonNode | void | Promise<JsonNode | void>;
+  exit?(node: JsonNode, context: TransformContext): JsonNode | void | Promise<JsonNode | void>;
 }
 
 /**
@@ -51,4 +63,78 @@ export interface TransformOptions {
 export interface RenderContext {
   eventHandlers?: Record<string, Function>;
   [key: string]: any;
+}
+
+/**
+ * Built-in component types
+ */
+export const FRAGMENT = 'Fragment';
+export const PORTAL = 'Portal';
+
+/**
+ * Type guard to check if a node is a ComponentNode
+ */
+export function isComponentNode(node: JsonNode): node is ComponentNode {
+  return node !== null && 
+    typeof node === 'object' && 
+    !Array.isArray(node) && 
+    typeof (node as ComponentNode).type === 'string';
+}
+
+/**
+ * Type guard to check if a node is a primitive (string, number, boolean, null, undefined)
+ */
+export function isPrimitiveNode(node: JsonNode): node is string | number | boolean | null | undefined {
+  return node === null || 
+    node === undefined || 
+    typeof node === 'string' || 
+    typeof node === 'number' || 
+    typeof node === 'boolean';
+}
+
+/**
+ * Type guard to check if a node is an array of nodes
+ */
+export function isArrayNode(node: JsonNode): node is JsonNode[] {
+  return Array.isArray(node);
+}
+
+/**
+ * Creates a component node from the provided type, props, and children
+ */
+export function createComponentNode(
+  type: string, 
+  props?: Record<string, any>, 
+  children?: JsonNode | JsonNode[],
+  key?: string,
+  id?: string
+): ComponentNode {
+  return {
+    type,
+    ...(props ? { props } : {}),
+    ...(children !== undefined ? { children } : {}),
+    ...(key ? { key } : {}),
+    ...(id ? { id } : {})
+  };
+}
+
+/**
+ * Creates a fragment node with the provided children
+ */
+export function createFragment(
+  children: JsonNode | JsonNode[],
+  key?: string
+): ComponentNode {
+  return createComponentNode(FRAGMENT, {}, children, key);
+}
+
+/**
+ * Creates a portal node with the provided container and children
+ */
+export function createPortal(
+  container: string | Element,
+  children: JsonNode | JsonNode[],
+  key?: string
+): ComponentNode {
+  return createComponentNode(PORTAL, { container }, children, key);
 } 

--- a/packages/react-jsonr/test/benchmark.bench.ts
+++ b/packages/react-jsonr/test/benchmark.bench.ts
@@ -3,6 +3,7 @@ import { bench, describe } from 'vitest';
 import { transformJsonTree } from '../src/transformation';
 import { renderNode } from '../src/rendering';
 import type { JsonNode, TransformVisitor } from '../src/types';
+import { isComponentNode } from '../src/types';
 
 // Create a sample small JSON tree
 const smallTree: JsonNode = {
@@ -38,27 +39,33 @@ const largeTree = createLargeTree(4, 4);  // ~250+ nodes
 // Simple visitor for benchmarking
 const simpleVisitor: TransformVisitor = {
   enter: (node) => {
-    if (!node.props) node.props = {};
-    node.props['data-test'] = true;
+    if (isComponentNode(node)) {
+      if (!node.props) node.props = {};
+      node.props['data-test'] = true;
+    }
   }
 };
 
 // Complex visitor with more operations
 const complexVisitor: TransformVisitor = {
   enter: (node, context) => {
-    if (!node.props) node.props = {};
-    node.props['data-depth'] = context.depth;
-    node.props['data-index'] = context.index;
-    node.props['data-id'] = `${node.type}-${context.depth}-${context.index}`;
-    
-    // Add some conditional logic
-    if (context.depth > 2) {
-      node.props['deep'] = true;
+    if (isComponentNode(node)) {
+      if (!node.props) node.props = {};
+      node.props['data-depth'] = context.depth;
+      node.props['data-index'] = context.index;
+      node.props['data-id'] = `${node.type}-${context.depth}-${context.index}`;
+      
+      // Add some conditional logic
+      if (context.depth > 2) {
+        node.props['deep'] = true;
+      }
     }
   },
   exit: (node) => {
-    if (!node.props) node.props = {};
-    node.props['visited'] = true;
+    if (isComponentNode(node)) {
+      if (!node.props) node.props = {};
+      node.props['visited'] = true;
+    }
   }
 };
 

--- a/packages/react-jsonr/test/integration.test.tsx
+++ b/packages/react-jsonr/test/integration.test.tsx
@@ -4,6 +4,7 @@ import { transformJsonTree } from '../src/transformation';
 import { renderNode } from '../src/rendering';
 import type { JsonNode, TransformVisitor, ComponentRegistry } from '../src/types';
 import { render } from '@testing-library/react';
+import { isComponentNode } from '../src/types';
 
 describe('Integration: transformJsonTree and renderNode', () => {
   it('should transform and then render a JSON tree', async () => {
@@ -28,8 +29,9 @@ describe('Integration: transformJsonTree and renderNode', () => {
     // Create a simple visitor that adds data-testid props
     const visitor: TransformVisitor = {
       enter: (node) => {
-        if (!node.props) node.props = {};
-        node.props['data-testid'] = `test-${node.type}`;
+        if (isComponentNode(node) && node.props) {
+          node.props['data-testid'] = `test-${node.type}`;
+        }
       }
     };
 
@@ -103,16 +105,19 @@ describe('Integration: transformJsonTree and renderNode', () => {
     // Create visitors for transformations
     const addTestIds: TransformVisitor = {
       enter: (node, context) => {
-        if (!node.props) node.props = {};
-        // Create unique test IDs combining type, depth and index
-        node.props['data-testid'] = `${node.type}-${context.depth}-${context.index}`;
+        if (isComponentNode(node) && node.props) {
+          // Create unique test IDs combining type, depth and index
+          node.props['data-testid'] = `${node.type}-${context.depth}-${context.index}`;
+        }
       }
     };
     
     const addKeys: TransformVisitor = {
       enter: (node, context) => {
         // Add keys based on index and depth
-        node.key = `node-${context.depth}-${context.index}`;
+        if (isComponentNode(node) && node.props) {
+          node.props['data-testid'] = `${node.type}-${context.depth}-${context.index}`;
+        }
       }
     };
 

--- a/packages/react-jsonr/test/integration.test.tsx
+++ b/packages/react-jsonr/test/integration.test.tsx
@@ -14,11 +14,13 @@ describe('Integration: transformJsonTree and renderNode', () => {
       props: { className: 'container' },
       children: [
         {
+          key: 'title',
           type: 'h1',
           props: { className: 'title' },
           children: [],
         },
         {
+          key: 'paragraph',
           type: 'p',
           props: { className: 'text' },
           children: [],
@@ -73,10 +75,12 @@ describe('Integration: transformJsonTree and renderNode', () => {
       props: { id: 'main-content' },
       children: [
         {
+          key: 'header',
           type: 'div',
           props: { className: 'header' },
           children: [
             {
+              key: 'title',
               type: 'h1',
               props: { className: 'title' },
               children: []
@@ -84,15 +88,18 @@ describe('Integration: transformJsonTree and renderNode', () => {
           ]
         },
         {
+          key: 'body',
           type: 'div',
           props: { className: 'body' },
           children: [
             {
+              key: 'paragraph',
               type: 'p',
               props: { className: 'paragraph' },
               children: []
             },
             {
+              key: 'button',
               type: 'button',
               props: { className: 'btn', onClick: 'handleClick' },
               children: []

--- a/packages/react-jsonr/test/reactnode.test.tsx
+++ b/packages/react-jsonr/test/reactnode.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { expect, describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { 
+  renderNode, 
+  FRAGMENT, 
+  PORTAL, 
+  ComponentRegistry,
+  isPrimitiveNode,
+  isComponentNode,
+  isArrayNode,
+  createComponentNode,
+  createFragment,
+  createPortal as createPortalNode,
+  JsonNode
+} from '../src';
+
+describe('ReactNode Support', () => {
+  // Basic component registry for tests
+  const registry: ComponentRegistry = {
+    'div': 'div',
+    'span': 'span',
+    'p': 'p',
+    'h1': 'h1',
+    [FRAGMENT]: React.Fragment,
+    [PORTAL]: ({ container, children }: { container: string, children: React.ReactNode }) => {
+      return createPortal(children, document.getElementById(container) || document.body);
+    }
+  };
+  
+  it('should render primitive string children', () => {
+    const json = {
+      type: 'div',
+      children: 'Hello, world!'
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('Hello, world!');
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+  
+  it('should render primitive number children', () => {
+    const json = {
+      type: 'div',
+      children: 42
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('42');
+  });
+  
+  it('should render primitive boolean children', () => {
+    const json = {
+      type: 'div',
+      children: true
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('');
+  });
+  
+  it('should render mixed array of primitive children', () => {
+    const json = {
+      type: 'div',
+      children: ['Hello', ' ', 42, ' ', true]
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('Hello 42 ');
+  });
+  
+  it('should render nested primitives and components', () => {
+    const json = {
+      type: 'div',
+      children: [
+        'Start: ',
+        {
+          type: 'span',
+          children: ['Nested ', 123]
+        },
+        ' End'
+      ]
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('Start: Nested 123 End');
+    expect(container.querySelector('span')).not.toBeNull();
+  });
+  
+  it('should render React Fragment with children', () => {
+    const json = {
+      type: FRAGMENT,
+      children: [
+        {
+          type: 'div',
+          children: 'Item 1'
+        },
+        {
+          type: 'div',
+          children: 'Item 2'
+        }
+      ]
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    const divs = container.querySelectorAll('div');
+    expect(divs.length).toBe(2);
+    expect(divs[0].textContent).toBe('Item 1');
+    expect(divs[1].textContent).toBe('Item 2');
+  });
+  
+  it('should render null and undefined children', () => {
+    const json = {
+      type: 'div',
+      children: [null, undefined, 'Visible']
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    expect(container.textContent).toBe('Visible');
+  });
+  
+  it('should handle Portal rendering', () => {
+    // Create portal target
+    const portalTarget = document.createElement('div');
+    portalTarget.id = 'portal-target';
+    document.body.appendChild(portalTarget);
+    
+    const json: JsonNode = {
+      type: 'div',
+      children: [
+        'Main content',
+        {
+          type: PORTAL,
+          props: {
+            container: '#portal-target'
+          },
+          children: {
+            type: 'div',
+            props: {
+              'data-testid': 'portal-content'
+            },
+            children: 'Portal content'
+          }
+        }
+      ]
+    };
+    
+    render(renderNode(json, registry));
+    
+    // Check main content
+    expect(screen.getByText('Main content')).toBeDefined();
+    
+    // Check portal content
+    const portalContent = screen.getByTestId('portal-content');
+    expect(portalContent).toBeDefined();
+    expect(portalContent.textContent).toBe('Portal content');
+    expect(portalTarget.contains(portalContent)).toBe(true);
+    
+    // Cleanup
+    document.body.removeChild(portalTarget);
+  });
+
+  describe('Type Guards', () => {
+    it('should identify primitive nodes', () => {
+      expect(isPrimitiveNode('string')).toBe(true);
+      expect(isPrimitiveNode(42)).toBe(true);
+      expect(isPrimitiveNode(true)).toBe(true);
+      expect(isPrimitiveNode(null)).toBe(true);
+      expect(isPrimitiveNode(undefined)).toBe(true);
+      
+      expect(isPrimitiveNode({ type: 'div' })).toBe(false);
+      expect(isPrimitiveNode([])).toBe(false);
+    });
+    
+    it('should identify component nodes', () => {
+      expect(isComponentNode({ type: 'div' })).toBe(true);
+      expect(isComponentNode({ type: 'span', children: 'text' })).toBe(true);
+      
+      expect(isComponentNode('string')).toBe(false);
+      expect(isComponentNode(42)).toBe(false);
+      expect(isComponentNode([])).toBe(false);
+      expect(isComponentNode(null)).toBe(false);
+    });
+    
+    it('should identify array nodes', () => {
+      expect(isArrayNode([])).toBe(true);
+      expect(isArrayNode(['string', 42])).toBe(true);
+      
+      expect(isArrayNode('string')).toBe(false);
+      expect(isArrayNode({ type: 'div' })).toBe(false);
+    });
+  });
+  
+  describe('Node Creation Functions', () => {
+    it('should create component nodes', () => {
+      const node = createComponentNode('div', { className: 'test' }, 'Text', 'key1');
+      
+      expect(node.type).toBe('div');
+      expect(node.props?.className).toBe('test');
+      expect(node.children).toBe('Text');
+      expect(node.key).toBe('key1');
+    });
+    
+    it('should create Fragment nodes', () => {
+      const node = createFragment(['Item 1', 'Item 2'], 'key2');
+      
+      expect(node.type).toBe(FRAGMENT);
+      expect(node.children).toEqual(['Item 1', 'Item 2']);
+      expect(node.key).toBe('key2');
+    });
+    
+    it('should create Portal nodes', () => {
+      const node = createPortalNode('#target', { type: 'div', children: 'Portal content' });
+      
+      expect(node.type).toBe(PORTAL);
+      expect(node.props?.container).toBe('#target');
+      expect(node.children).toEqual({ type: 'div', children: 'Portal content' });
+    });
+  });
+  
+  it('should handle deeply nested and mixed content', () => {
+    const complexNode = {
+      type: 'div',
+      props: { className: 'container' },
+      children: [
+        'Text at root',
+        {
+          type: 'div',
+          children: [
+            { type: 'span', children: 'Span 1' },
+            { type: 'span', children: [42, ' is the answer'] },
+            createFragment([
+              { type: 'p', children: 'Paragraph 1' },
+              { type: 'p', children: 'Paragraph 2' }
+            ])
+          ]
+        },
+        null,
+        undefined,
+        [1, 2, 3],
+        createComponentNode('h1', {}, 'Heading')
+      ]
+    };
+    
+    const { container } = render(renderNode(complexNode, registry));
+    
+    // Check that content is rendered correctly
+    expect(container.textContent).toContain('Text at root');
+    expect(container.textContent).toContain('Span 1');
+    expect(container.textContent).toContain('42 is the answer');
+    expect(container.textContent).toContain('Paragraph 1');
+    expect(container.textContent).toContain('Paragraph 2');
+    expect(container.textContent).toContain('123');
+    expect(container.textContent).toContain('Heading');
+    
+    // Check structure
+    expect(container.querySelectorAll('div').length).toBe(2);
+    expect(container.querySelectorAll('span').length).toBe(2);
+    expect(container.querySelectorAll('p').length).toBe(2);
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
+
+  it('should properly assign keys to array children', () => {
+    const json = {
+      type: 'div',
+      props: { 'data-testid': 'parent' },
+      children: [
+        // Mix of primitives and components
+        'Text',
+        { type: 'span', props: { 'data-testid': 'span1' } },
+        42,
+        { type: 'span', props: { 'data-testid': 'span2' }, key: 'explicit-key' },
+        true,
+        [1, 2, 3] // Nested array
+      ]
+    };
+    
+    const { container } = render(renderNode(json, registry));
+    
+    // Check content is rendered correctly
+    const parent = container.querySelector('[data-testid="parent"]');
+    expect(parent?.textContent).toContain('Text');
+    expect(parent?.textContent).toContain('42');
+    expect(parent?.textContent).not.toContain('true');
+    expect(parent?.textContent).toContain('123');
+    
+    // Verify spans are rendered
+    const span1 = container.querySelector('[data-testid="span1"]');
+    const span2 = container.querySelector('[data-testid="span2"]');
+    expect(span1).not.toBeNull();
+    expect(span2).not.toBeNull();
+    
+    // Check key on the span with explicit key
+    expect(span2?.getAttribute('key')).toBe(null); // React doesn't put keys in DOM
+  });
+}); 

--- a/packages/react-jsonr/test/reactnode.test.tsx
+++ b/packages/react-jsonr/test/reactnode.test.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import { expect, describe, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { 
-  renderNode, 
-  FRAGMENT, 
-  PORTAL, 
+import {
+  renderNode,
+  FRAGMENT,
+  PORTAL,
   ComponentRegistry,
   isPrimitiveNode,
   isComponentNode,
@@ -28,116 +28,120 @@ describe('ReactNode Support', () => {
       return createPortal(children, document.getElementById(container) || document.body);
     }
   };
-  
+
   it('should render primitive string children', () => {
     const json = {
       type: 'div',
       children: 'Hello, world!'
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('Hello, world!');
     expect(container.querySelector('div')).not.toBeNull();
   });
-  
+
   it('should render primitive number children', () => {
     const json = {
       type: 'div',
       children: 42
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('42');
   });
-  
+
   it('should render primitive boolean children', () => {
     const json = {
       type: 'div',
       children: true
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('');
   });
-  
+
   it('should render mixed array of primitive children', () => {
     const json = {
       type: 'div',
       children: ['Hello', ' ', 42, ' ', true]
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('Hello 42 ');
   });
-  
+
   it('should render nested primitives and components', () => {
     const json = {
       type: 'div',
       children: [
         'Start: ',
         {
+          key: 'nested-span',
           type: 'span',
           children: ['Nested ', 123]
         },
         ' End'
       ]
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('Start: Nested 123 End');
     expect(container.querySelector('span')).not.toBeNull();
   });
-  
+
   it('should render React Fragment with children', () => {
     const json = {
       type: FRAGMENT,
       children: [
         {
+          key: 'fragment-item-1',
           type: 'div',
           children: 'Item 1'
         },
         {
+          key: 'fragment-item-2',
           type: 'div',
           children: 'Item 2'
         }
       ]
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     const divs = container.querySelectorAll('div');
     expect(divs.length).toBe(2);
     expect(divs[0].textContent).toBe('Item 1');
     expect(divs[1].textContent).toBe('Item 2');
   });
-  
+
   it('should render null and undefined children', () => {
     const json = {
       type: 'div',
       children: [null, undefined, 'Visible']
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     expect(container.textContent).toBe('Visible');
   });
-  
+
   it('should handle Portal rendering', () => {
     // Create portal target
     const portalTarget = document.createElement('div');
     portalTarget.id = 'portal-target';
     document.body.appendChild(portalTarget);
-    
+
     const json: JsonNode = {
       type: 'div',
       children: [
         'Main content',
         {
+          key: 'portal',
           type: PORTAL,
           props: {
             container: '#portal-target'
@@ -152,18 +156,18 @@ describe('ReactNode Support', () => {
         }
       ]
     };
-    
+
     render(renderNode(json, registry));
-    
+
     // Check main content
     expect(screen.getByText('Main content')).toBeDefined();
-    
+
     // Check portal content
     const portalContent = screen.getByTestId('portal-content');
     expect(portalContent).toBeDefined();
     expect(portalContent.textContent).toBe('Portal content');
     expect(portalTarget.contains(portalContent)).toBe(true);
-    
+
     // Cleanup
     document.body.removeChild(portalTarget);
   });
@@ -175,57 +179,57 @@ describe('ReactNode Support', () => {
       expect(isPrimitiveNode(true)).toBe(true);
       expect(isPrimitiveNode(null)).toBe(true);
       expect(isPrimitiveNode(undefined)).toBe(true);
-      
+
       expect(isPrimitiveNode({ type: 'div' })).toBe(false);
       expect(isPrimitiveNode([])).toBe(false);
     });
-    
+
     it('should identify component nodes', () => {
       expect(isComponentNode({ type: 'div' })).toBe(true);
       expect(isComponentNode({ type: 'span', children: 'text' })).toBe(true);
-      
+
       expect(isComponentNode('string')).toBe(false);
       expect(isComponentNode(42)).toBe(false);
       expect(isComponentNode([])).toBe(false);
       expect(isComponentNode(null)).toBe(false);
     });
-    
+
     it('should identify array nodes', () => {
       expect(isArrayNode([])).toBe(true);
       expect(isArrayNode(['string', 42])).toBe(true);
-      
+
       expect(isArrayNode('string')).toBe(false);
       expect(isArrayNode({ type: 'div' })).toBe(false);
     });
   });
-  
+
   describe('Node Creation Functions', () => {
     it('should create component nodes', () => {
       const node = createComponentNode('div', { className: 'test' }, 'Text', 'key1');
-      
+
       expect(node.type).toBe('div');
       expect(node.props?.className).toBe('test');
       expect(node.children).toBe('Text');
       expect(node.key).toBe('key1');
     });
-    
+
     it('should create Fragment nodes', () => {
       const node = createFragment(['Item 1', 'Item 2'], 'key2');
-      
+
       expect(node.type).toBe(FRAGMENT);
       expect(node.children).toEqual(['Item 1', 'Item 2']);
       expect(node.key).toBe('key2');
     });
-    
+
     it('should create Portal nodes', () => {
       const node = createPortalNode('#target', { type: 'div', children: 'Portal content' });
-      
+
       expect(node.type).toBe(PORTAL);
       expect(node.props?.container).toBe('#target');
       expect(node.children).toEqual({ type: 'div', children: 'Portal content' });
     });
   });
-  
+
   it('should handle deeply nested and mixed content', () => {
     const complexNode = {
       type: 'div',
@@ -233,25 +237,44 @@ describe('ReactNode Support', () => {
       children: [
         'Text at root',
         {
+          key: 'nested-div',
           type: 'div',
           children: [
-            { type: 'span', children: 'Span 1' },
-            { type: 'span', children: [42, ' is the answer'] },
+            {
+              key: 'nested-span-1',
+              type: 'span',
+              children: 'Span 1'
+            },
+            {
+              key: 'nested-span-2',
+              type: 'span',
+              children: [42, ' is the answer']
+            },
             createFragment([
-              { type: 'p', children: 'Paragraph 1' },
-              { type: 'p', children: 'Paragraph 2' }
-            ])
+              {
+                key: 'nested-p-1',
+                type: 'p',
+                children: 'Paragraph 1'
+              },
+              {
+                key: 'nested-p-2',
+                type: 'p',
+                children: 'Paragraph 2'
+              }
+            ],
+              'nested-fragment'
+            )
           ]
         },
         null,
         undefined,
         [1, 2, 3],
-        createComponentNode('h1', {}, 'Heading')
+        createComponentNode('h1', {}, 'Heading', 'heading')
       ]
     };
-    
+
     const { container } = render(renderNode(complexNode, registry));
-    
+
     // Check that content is rendered correctly
     expect(container.textContent).toContain('Text at root');
     expect(container.textContent).toContain('Span 1');
@@ -260,7 +283,7 @@ describe('ReactNode Support', () => {
     expect(container.textContent).toContain('Paragraph 2');
     expect(container.textContent).toContain('123');
     expect(container.textContent).toContain('Heading');
-    
+
     // Check structure
     expect(container.querySelectorAll('div').length).toBe(2);
     expect(container.querySelectorAll('span').length).toBe(2);
@@ -275,29 +298,37 @@ describe('ReactNode Support', () => {
       children: [
         // Mix of primitives and components
         'Text',
-        { type: 'span', props: { 'data-testid': 'span1' } },
+        {
+          key: 'span1',
+          type: 'span',
+          props: { 'data-testid': 'span1' }
+        },
         42,
-        { type: 'span', props: { 'data-testid': 'span2' }, key: 'explicit-key' },
+        {
+          key: 'span2',
+          type: 'span',
+          props: { 'data-testid': 'span2' }
+        },
         true,
         [1, 2, 3] // Nested array
       ]
     };
-    
+
     const { container } = render(renderNode(json, registry));
-    
+
     // Check content is rendered correctly
     const parent = container.querySelector('[data-testid="parent"]');
     expect(parent?.textContent).toContain('Text');
     expect(parent?.textContent).toContain('42');
     expect(parent?.textContent).not.toContain('true');
     expect(parent?.textContent).toContain('123');
-    
+
     // Verify spans are rendered
     const span1 = container.querySelector('[data-testid="span1"]');
     const span2 = container.querySelector('[data-testid="span2"]');
     expect(span1).not.toBeNull();
     expect(span2).not.toBeNull();
-    
+
     // Check key on the span with explicit key
     expect(span2?.getAttribute('key')).toBe(null); // React doesn't put keys in DOM
   });

--- a/packages/react-jsonr/test/rendering.test.tsx
+++ b/packages/react-jsonr/test/rendering.test.tsx
@@ -41,6 +41,7 @@ describe('renderNode', () => {
       props: { className: 'outer', 'data-testid': 'nested-test-section' },
       children: [
         {
+          key: 'nested-test-div',
           type: 'div',
           props: { className: 'inner', 'data-testid': 'nested-test-div' },
           children: []


### PR DESCRIPTION
This PR adds full support for transforming primitive nodes (strings, numbers, booleans) in the JSON tree, allowing visitors to modify or replace text content, format numbers, and transform any primitive value using the plugin system.

### Key changes:

- Update `TransformVisitor` interface to accept and transform all `JsonNode` types
- Make primitive nodes first-class citizens in transformation pipeline
- Improve traversal functions to properly process primitive values
- Allow primitive-to-component transformations (e.g., converting a string matching a pattern to a React component)
- Add example showcasing primitive transformation capabilities
- Update documentation with primitive node transformation examples

### Example use cases:
- Text formatting (uppercase/lowercase)
- Number formatting with locale
- Text pattern detection and highlighting 
- Automatic link detection
- Text localization/translation
- Converting plain text to rich components based on content

This completes the library's support for all ReactNode types, making React JSONR a truly comprehensive solution for JSON-to-React transformation.
