### PR TITLE
feat(registry): add default registry with HTML elements and special components

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { ImageZoom } from 'fumadocs-ui/components/image-zoom';
 import GithubIcon from '@/components/github-icon';
-import { renderNode } from 'react-jsonr';
+import { renderNode, transformJsonTree, createRegistry } from 'react-jsonr';
 import type { JsonNode, ComponentRegistry } from 'react-jsonr';
 
 // Define the components that will be used in the JSON
@@ -126,14 +126,14 @@ export default async function HomePage() {
           <div className="bg-fd-card text-fd-card-foreground p-4 rounded-lg border border-fd-border overflow-auto">
             <DynamicCodeBlock 
               lang="tsx" 
-              code={`import { renderNode, transformJsonTree } from 'react-jsonr';
+              code={`import { renderNode, transformJsonTree, createRegistry } from 'react-jsonr';
 
-// Define component registry
-const registry = {
+// Define component registry with your custom components
+const registry = createRegistry({
   Form: MyFormComponent,
   Input: MyInputComponent,
   Button: MyButtonComponent,
-};
+});
 
 // JSON definition
 const jsonDefinition = {

--- a/apps/docs/content/docs/api.mdx
+++ b/apps/docs/content/docs/api.mdx
@@ -119,6 +119,21 @@ type ComponentRegistry = {
 
 The keys are the type names used in JSON, and the values are either React components or strings (for native HTML elements).
 
+You can create a registry using the `createRegistry` function, which automatically includes all HTML elements and special components like Fragment and Portal:
+
+```typescript
+import { createRegistry } from 'react-jsonr';
+
+// Create a registry with just your custom components
+// All HTML elements, Fragment, and Portal are automatically included
+const registry = createRegistry({
+  CustomComponent: MyCustomComponent,
+  SpecialButton: ({ children, ...props }) => (
+    <button className="special-btn" {...props}>{children}</button>
+  )
+});
+```
+
 ### TransformVisitor
 
 Plugin interface for transforming the JSON tree.

--- a/apps/docs/content/docs/examples/contact-form.mdx
+++ b/apps/docs/content/docs/examples/contact-form.mdx
@@ -13,17 +13,15 @@ Here's the full implementation:
 
 ```tsx
 import React, { useState, useEffect } from 'react';
-import { renderNode, transformJsonTree } from 'react-jsonr';
+import { renderNode, transformJsonTree, createRegistry } from 'react-jsonr';
 import { Form, Input, Button } from './components';
 
 // Create a component registry
-const registry = {
+const registry = createRegistry({
   Form,
   Input,
-  Button,
-  div: 'div',
-  p: 'p',
-};
+  Button
+});
 
 // Define event handlers
 const eventHandlers = {

--- a/apps/docs/content/docs/examples/index.mdx
+++ b/apps/docs/content/docs/examples/index.mdx
@@ -52,14 +52,13 @@ const Text = ({ text, ...props }) => <p {...props}>{text}</p>;
 These components are registered in a component registry for use with React JSONR:
 
 ```tsx
-const registry = {
+import { createRegistry } from 'react-jsonr';
+
+const registry = createRegistry({
   Form,
   Input,
   Button,
-  Text,
-  div: 'div',
-  h1: 'h1',
-  p: 'p',
-  // ... other HTML elements as needed
-};
+  Text
+  // All HTML elements are automatically included
+});
 ``` 

--- a/apps/docs/content/docs/examples/user-profile.mdx
+++ b/apps/docs/content/docs/examples/user-profile.mdx
@@ -54,16 +54,14 @@ const Text = ({ text, ...props }) => <p {...props}>{text}</p>;
 
 ```tsx
 // Register our components
-const registry = {
+import { createRegistry } from 'react-jsonr';
+
+const registry = createRegistry({
   UserProfile,
   ProfileSection,
   AdminPanel,
-  Text,
-  div: 'div',
-  span: 'span',
-  h4: 'h4',
-  button: 'button',
-};
+  Text
+});
 
 // Define event handlers
 const eventHandlers = {

--- a/apps/docs/content/docs/getting-started/basic-usage.mdx
+++ b/apps/docs/content/docs/getting-started/basic-usage.mdx
@@ -19,7 +19,7 @@ Let's start with a simple example of rendering a contact form from JSON:
 
 ```tsx
 import React, { useState, useEffect } from 'react';
-import { renderNode, transformJsonTree } from 'react-jsonr';
+import { renderNode, transformJsonTree, createRegistry } from 'react-jsonr';
 
 // Define your components
 const Form = ({ title, children, ...props }) => (
@@ -40,12 +40,13 @@ const Button = ({ label, ...props }) => (
   <button type="button" {...props}>{label}</button>
 );
 
-// 1. Create a component registry (whitelist of allowed components)
-const registry = {
+// 1. Create a component registry with your custom components
+// (All HTML elements, Fragment, and Portal are already included)
+const registry = createRegistry({
   Form,
   Input,
   Button,
-};
+});
 
 // 2. Define event handlers that can be referenced from JSON
 const eventHandlers = {

--- a/packages/react-jsonr/README.md
+++ b/packages/react-jsonr/README.md
@@ -8,7 +8,7 @@ React JSONR is a lightweight, extensible library that converts JSON definitions 
 - **Complete ReactNode Support**: Handle all React node types including primitives (strings, numbers, booleans), arrays, Fragment, Portal, and components.
 - **Plugin-Based Transformation**: Insert synchronous or asynchronous plugins to mutate, enrich, or validate the JSON tree before rendering.
 - **Flexible Traversal**: Supports configurable traversal orders (e.g., depth-first pre-order, post-order, or breadth-first) with options to skip subtrees.
-- **Component Registry**: Uses a whitelist of allowed component types, ensuring that only registered components are rendered.
+- **Component Registry**: Uses a registry of allowed component types, with built-in support for all HTML elements, Fragment, and Portal.
 - **Event Handler Mapping**: Safely maps string-based event handler references (e.g., "onClick": "submitForm") to actual functions provided by your application.
 - **Performance Optimizations**: Designed to handle moderately large JSON trees efficiently, with support for caching and skipping unnecessary nodes.
 - **Zero External Dependencies**: Built with React (>= v18) and TypeScript, with minimal overhead.
@@ -30,15 +30,15 @@ pnpm add react-jsonr
 
 ```tsx
 import React, { useState, useEffect } from 'react';
-import { renderNode, transformJsonTree } from 'react-jsonr';
+import { renderNode, transformJsonTree, createRegistry } from 'react-jsonr';
 
-// Define component registry
-const registry = {
+// Define component registry with your custom components
+// (All HTML elements, Fragment, and Portal are already included)
+const registry = createRegistry({
   Form: MyFormComponent,
   Input: MyInputComponent,
-  Button: MyButtonComponent,
-  div: 'div' // Native HTML elements can be included too
-};
+  Button: MyButtonComponent
+});
 
 // Define event handlers
 const eventHandlers = {
@@ -83,15 +83,16 @@ function App() {
 React JSONR fully supports all React node types, allowing you to mix component nodes with primitive values:
 
 ```tsx
-import { renderNode, FRAGMENT, PORTAL } from 'react-jsonr';
+import { renderNode, createRegistry, FRAGMENT, PORTAL } from 'react-jsonr';
 
-// Define component registry with special components
-const registry = {
-  div: 'div',
-  span: 'span',
-  [FRAGMENT]: React.Fragment,
-  [PORTAL]: ({ container, children }) => React.createPortal(children, document.querySelector(container))
-};
+// Create registry with just your custom components
+// HTML elements, Fragment, and Portal are automatically included
+const registry = createRegistry({
+  CustomComponent: MyCustomComponent,
+  SpecialButton: ({ children, ...props }) => (
+    <button className="special-btn" {...props}>{children}</button>
+  )
+});
 
 // Example using different node types
 const jsonDefinition = {
@@ -109,7 +110,7 @@ const jsonDefinition = {
       children: [' - ', 'Welcome', '!']
     },
     
-    // React Fragment
+    // React Fragment (automatically supported)
     {
       type: FRAGMENT,
       children: [
@@ -118,17 +119,24 @@ const jsonDefinition = {
       ]
     },
     
-    // React Portal
+    // React Portal (automatically supported)
     {
       type: PORTAL,
       props: { container: '#modal-root' },
       children: { type: 'div', children: 'Portal Content' }
+    },
+
+    // Custom component
+    {
+      type: 'CustomComponent',
+      props: { customProp: 'value' },
+      children: 'Using a custom component'
     }
   ]
 };
 
 const component = renderNode(jsonDefinition, registry);
-``` 
+```
 
 ## Advanced Usage with Plugins
 

--- a/packages/react-jsonr/examples/basic-rendering.tsx
+++ b/packages/react-jsonr/examples/basic-rendering.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderNode, JsonNode } from '../src';
+import { renderNode, JsonNode, createRegistry } from '../src';
 
 // Basic JSON definition for a simple UI
 const jsonDefinition: JsonNode = {
@@ -55,13 +55,8 @@ const jsonDefinition: JsonNode = {
 };
 
 // Define component registry
-const registry = {
-  div: 'div',
-  h2: 'h2',
-  p: 'p',
-  button: 'button',
-  span: 'span'
-};
+// No need to list HTML elements as they're included automatically
+const registry = createRegistry();
 
 export default function BasicRenderingExample() {
   // Render the JSON definition to React components

--- a/packages/react-jsonr/examples/component-transformation.tsx
+++ b/packages/react-jsonr/examples/component-transformation.tsx
@@ -7,6 +7,7 @@ import {
   createComponentNode, 
   JsonNode 
 } from '../src';
+import { createRegistry } from '../src';
 
 // Example JSON with various components
 const jsonDefinition: JsonNode = {
@@ -50,17 +51,8 @@ const jsonDefinition: JsonNode = {
   ]
 };
 
-// Define component registry
-const registry = {
-  div: 'div',
-  h1: 'h1',
-  p: 'p',
-  ul: 'ul',
-  li: 'li',
-  button: 'button',
-  strong: 'strong',
-  span: 'span'
-};
+// Define component registry with HTML elements automatically included
+const registry = createRegistry();
 
 // Transform 1: Add styles to all headers
 const headerStyleTransform: TransformVisitor = {

--- a/packages/react-jsonr/examples/conditional-rendering.tsx
+++ b/packages/react-jsonr/examples/conditional-rendering.tsx
@@ -8,6 +8,7 @@ import {
   createFragment,
   JsonNode 
 } from '../src';
+import { createRegistry } from '../src';
 
 // JSON definition with content that will be conditionally rendered
 const jsonDefinition: JsonNode = {
@@ -123,18 +124,8 @@ const jsonDefinition: JsonNode = {
   ]
 };
 
-// Component registry
-const registry = {
-  div: 'div',
-  h1: 'h1',
-  h2: 'h2',
-  h3: 'h3',
-  p: 'p',
-  button: 'button',
-  ul: 'ul',
-  li: 'li',
-  span: 'span'
-};
+// Component registry with HTML elements automatically included
+const registry = createRegistry();
 
 interface UserState {
   isLoggedIn: boolean;

--- a/packages/react-jsonr/examples/dynamic-form.tsx
+++ b/packages/react-jsonr/examples/dynamic-form.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { renderNode, transformJsonTree, isComponentNode, JsonNode, ComponentNode } from '../src';
+import { renderNode, transformJsonTree, isComponentNode, JsonNode, ComponentNode, createRegistry } from '../src';
 
 // Initial form definition
 const initialFormDefinition: ComponentNode = {
@@ -97,19 +97,8 @@ const initialFormDefinition: ComponentNode = {
   ]
 };
 
-// Component registry
-const registry = {
-  form: 'form',
-  div: 'div',
-  h2: 'h2',
-  label: 'label',
-  input: 'input',
-  select: 'select',
-  option: 'option',
-  textarea: 'textarea',
-  button: 'button',
-  p: 'p'
-};
+// Component registry - HTML elements are now automatically included
+const registry = createRegistry();
 
 export default function DynamicFormExample() {
   const [formDefinition, setFormDefinition] = useState(initialFormDefinition);

--- a/packages/react-jsonr/examples/primitive-transforms.tsx
+++ b/packages/react-jsonr/examples/primitive-transforms.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderNode, transformJsonTree, TransformVisitor, isComponentNode, isPrimitiveNode, createComponentNode } from '../src';
+import { renderNode, transformJsonTree, TransformVisitor, isComponentNode, isPrimitiveNode, createComponentNode, createRegistry } from '../src';
 
 // Example JSON definition with primitive values
 const jsonDefinition = {
@@ -20,13 +20,10 @@ const jsonDefinition = {
   ]
 };
 
-// Define component registry
-const registry = {
-  div: 'div',
-  span: 'span',
-  button: 'button',
-  strong: 'strong'
-};
+// Define component registry with built-in HTML elements
+const registry = createRegistry({
+  strong: 'strong' // This is unnecessary as HTML elements are automatically included
+});
 
 // Example 1: Plugin to uppercase all string primitive nodes
 const uppercaseStringsPlugin: TransformVisitor = {

--- a/packages/react-jsonr/src/index.ts
+++ b/packages/react-jsonr/src/index.ts
@@ -1,6 +1,7 @@
 // Main entry point for React-JSONR
 export { renderNode } from './rendering';
 export { transformJsonTree, traverseJsonTree } from './transformation';
+export { createRegistry } from './registry';
 export type { 
   JsonNode, 
   ComponentNode, 

--- a/packages/react-jsonr/src/registry.ts
+++ b/packages/react-jsonr/src/registry.ts
@@ -1,0 +1,58 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { ComponentRegistry, FRAGMENT, PORTAL } from './types';
+
+// Define the base registry with special components
+const baseRegistry = {
+  [FRAGMENT]: React.Fragment,
+  [PORTAL]: ({ container, children }: { container: string | Element, children: React.ReactNode }) => {
+    let targetContainer: Element | DocumentFragment;
+    
+    if (typeof container === 'string') {
+      const foundElement = document.querySelector(container);
+      if (!foundElement) {
+        console.warn(`Portal container not found: ${container}`);
+        targetContainer = document.body;
+      } else {
+        targetContainer = foundElement;
+      }
+    } else {
+      targetContainer = container || document.body;
+    }
+      
+    return createPortal(children, targetContainer);
+  }
+};
+
+/**
+ * Creates a registry by merging custom components with automatic HTML element handling.
+ * 
+ * This function creates a registry that:
+ * 1. Uses your custom components for registered types
+ * 2. Automatically handles Fragment and Portal special components
+ * 3. Treats any other string type as an HTML element (including custom elements)
+ * 
+ * Note: String-based component types like 'div', 'span', or even 'custom-element'
+ * will be rendered as HTML elements. If you want to prevent certain string types
+ * from becoming elements, you need to override them in your custom components.
+ */
+export function createRegistry(customComponents: ComponentRegistry = {}): ComponentRegistry {
+  // Create a new proxy that first checks custom components, then falls back to defaults
+  return new Proxy(customComponents, {
+    get: (target, prop: string | symbol) => {
+      // First check if the property is in custom components
+      if (prop in target) {
+        return Reflect.get(target, prop);
+      }
+      
+      // Then check if it's one of our special components
+      if (typeof prop === 'string' && prop in baseRegistry) {
+        return baseRegistry[prop as keyof typeof baseRegistry];
+      }
+      
+      // For string properties, return the property name to create HTML elements
+      // This effectively enables ALL HTML elements including custom elements
+      return typeof prop === 'string' ? prop : undefined;
+    }
+  });
+} 

--- a/packages/react-jsonr/test/benchmark.bench.ts
+++ b/packages/react-jsonr/test/benchmark.bench.ts
@@ -4,6 +4,7 @@ import { transformJsonTree } from '../src/transformation';
 import { renderNode } from '../src/rendering';
 import type { JsonNode, TransformVisitor } from '../src/types';
 import { isComponentNode } from '../src/types';
+import { createRegistry } from '../src';
 
 // Create a sample small JSON tree
 const smallTree: JsonNode = {
@@ -70,12 +71,7 @@ const complexVisitor: TransformVisitor = {
 };
 
 // Component registry for rendering benchmarks
-const registry = {
-  div: 'div',
-  span: 'span',
-  h1: 'h1',
-  p: 'p'
-};
+const registry = createRegistry();
 
 describe('transformJsonTree performance', () => {
   bench('small tree - simple visitor', async () => {

--- a/packages/react-jsonr/test/registry.test.tsx
+++ b/packages/react-jsonr/test/registry.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { createRegistry } from '../src/registry';
+import { renderNode } from '../src/rendering';
+import { FRAGMENT, PORTAL } from '../src/types';
+import { render } from '@testing-library/react';
+
+describe('createRegistry', () => {
+  it('should provide access to HTML elements', () => {
+    const registry = createRegistry();
+    
+    // HTML elements should be accessible as properties
+    expect(registry.div).toBe('div');
+    expect(registry.span).toBe('span');
+    expect(registry.h1).toBe('h1');
+    expect(registry.button).toBe('button');
+    expect(registry.input).toBe('input');
+  });
+  
+  it('should include Fragment by default', () => {
+    const registry = createRegistry();
+    
+    // Fragment should be included
+    expect(registry[FRAGMENT]).toBe(React.Fragment);
+  });
+  
+  it('should include Portal by default', () => {
+    const registry = createRegistry();
+    
+    // Portal should be included
+    expect(typeof registry[PORTAL]).toBe('function');
+  });
+  
+  it('should allow custom components to be added', () => {
+    const CustomComponent = () => <div>Custom Component</div>;
+    
+    const registry = createRegistry({
+      Custom: CustomComponent
+    });
+    
+    // Should include both HTML elements and custom components
+    expect(registry.div).toBe('div');
+    expect(registry.Custom).toBe(CustomComponent);
+  });
+  
+  it('should allow custom components to override HTML elements', () => {
+    const CustomDiv = (props: any) => <div className="custom-div" {...props} />;
+    
+    const registry = createRegistry({
+      div: CustomDiv
+    });
+    
+    // Custom div should override the default
+    expect(registry.div).toBe(CustomDiv);
+    expect(registry.span).toBe('span'); // Other elements should be unaffected
+  });
+  
+  it('should render HTML elements correctly', () => {
+    const registry = createRegistry();
+    
+    const node = {
+      type: 'div',
+      props: { 'data-testid': 'test-element' },
+      children: 'Test content'
+    };
+    
+    const element = renderNode(node, registry);
+    const { getByTestId } = render(<>{element}</>);
+    
+    const divElement = getByTestId('test-element');
+    expect(divElement).toBeDefined();
+    expect(divElement.textContent).toBe('Test content');
+  });
+  
+  it('should render Fragment correctly', () => {
+    const registry = createRegistry();
+    
+    const node = {
+      type: FRAGMENT,
+      children: [
+        {
+          key: 'fragment-child-1',
+          type: 'div',
+          props: { 'data-testid': 'fragment-child-1' },
+          children: 'Child 1'
+        },
+        {
+          key: 'fragment-child-2',
+          type: 'div',
+          props: { 'data-testid': 'fragment-child-2' },
+          children: 'Child 2'
+        }
+      ]
+    };
+    
+    const element = renderNode(node, registry);
+    const { getByTestId } = render(<div data-testid="wrapper">{element}</div>);
+    
+    const wrapper = getByTestId('wrapper');
+    const child1 = getByTestId('fragment-child-1');
+    const child2 = getByTestId('fragment-child-2');
+    
+    expect(child1.parentElement).toBe(wrapper);
+    expect(child2.parentElement).toBe(wrapper);
+  });
+}); 

--- a/packages/react-jsonr/test/rendering.test.tsx
+++ b/packages/react-jsonr/test/rendering.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderNode } from '../src/rendering';
+import { createRegistry } from '../src/registry';
 import type { JsonNode, ComponentRegistry, RenderContext } from '../src/types';
 import { render } from '@testing-library/react';
 
@@ -18,10 +19,8 @@ describe('renderNode', () => {
       children: []
     };
 
-    // Create a registry with the div component
-    const registry: ComponentRegistry = {
-      div: 'div'
-    };
+    // Create a registry using createRegistry
+    const registry = createRegistry();
 
     // Render the node
     const element = renderNode(node, registry);
@@ -49,11 +48,8 @@ describe('renderNode', () => {
       ]
     };
 
-    // Create a registry with the components
-    const registry: ComponentRegistry = {
-      section: 'section',
-      div: 'div'
-    };
+    // Create a registry using createRegistry
+    const registry = createRegistry();
 
     // Render the node
     const element = renderNode(node, registry);
@@ -85,10 +81,8 @@ describe('renderNode', () => {
       children: []
     };
 
-    // Create a registry and context with event handlers
-    const registry: ComponentRegistry = {
-      button: 'button'
-    };
+    // Create a registry using createRegistry
+    const registry = createRegistry();
     
     const context: RenderContext = {
       eventHandlers: {
@@ -108,22 +102,66 @@ describe('renderNode', () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should return null for unknown component types', () => {
-    // Define a JSON node with an unknown type
-    const node: JsonNode = {
-      type: 'unknown',
+  it('should handle both registered and unregistered component types', () => {
+    // Create a custom component class
+    class CustomComponent extends React.Component {
+      render() {
+        return <div data-testid="custom-class-component">Custom Component</div>;
+      }
+    }
+    
+    // Create a registry with the custom component
+    const registry = createRegistry({
+      CustomComponent
+    });
+    
+    // Test with registered component - should render the component
+    const registeredNode: JsonNode = {
+      type: 'CustomComponent',
       props: {},
       children: []
     };
+    
+    const registeredElement = renderNode(registeredNode, registry);
+    const { getByTestId } = render(<>{registeredElement}</>);
+    const customElement = getByTestId('custom-class-component');
+    expect(customElement).toBeDefined();
+    
+    // Test with unregistered component name
+    const unregisteredNode: JsonNode = {
+      type: 'UnregisteredComponent',
+      props: { 'data-testid': 'html-fallback' },
+      children: 'Should render as HTML element'
+    };
+    
+    const unregisteredElement = renderNode(unregisteredNode, registry);
+    const { getByTestId: getByTestId2 } = render(<>{unregisteredElement}</>);
+    const fallbackElement = getByTestId2('html-fallback');
+    expect(fallbackElement).toBeDefined();
+    expect(fallbackElement.tagName.toLowerCase()).toBe('unregisteredcomponent');
+  });
 
-    // Create an empty registry
-    const registry: ComponentRegistry = {};
+  it('should create custom HTML elements for unknown string types', () => {
+    // Define a JSON node with a string type that's not a registered component
+    // but should be treated as a custom HTML element
+    const node: JsonNode = {
+      type: 'custom-element',
+      props: { 'data-testid': 'custom-element-test' },
+      children: 'Custom element content'
+    };
+
+    // Create a registry with no custom components
+    const registry = createRegistry();
 
     // Render the node
     const element = renderNode(node, registry);
+    const { getByTestId } = render(<>{element}</>);
     
-    // Assert that null was returned
-    expect(element).toBeNull();
-    expect(console.warn).toHaveBeenCalledWith('Unknown component type: unknown');
+    // Assert that a custom HTML element was created
+    const customElement = getByTestId('custom-element-test');
+    expect(customElement).toBeDefined();
+    expect(customElement.tagName.toLowerCase()).toBe('custom-element');
+    expect(customElement.textContent).toBe('Custom element content');
+    expect(console.warn).not.toHaveBeenCalled();
   });
 }); 


### PR DESCRIPTION
This PR introduces a new `createRegistry` function that automatically includes all HTML elements, Fragment, and Portal components, eliminating the need to manually register these commonly used components.

### Changes
- Created a new `registry.ts` module with Proxy-based implementation
- Added `createRegistry` function that allows merging custom components with default HTML elements
- Updated all examples, tests, and documentation to use the new approach

### Benefits
- Improved developer experience by reducing boilerplate code
- Automatic support for all HTML elements without explicit registration
- Built-in support for Fragment and Portal components
- Backward compatible with existing code

### Testing
- Added new tests specifically for the `createRegistry` function
- Updated existing tests to use the new approach
- All tests passing